### PR TITLE
[✨Feat] 集成 RailGPT WebView2 与 API 设置一体化

### DIFF
--- a/RailGo.AI/Models/AISettingsPayload.cs
+++ b/RailGo.AI/Models/AISettingsPayload.cs
@@ -1,0 +1,78 @@
+using System.Text.Json.Serialization;
+
+namespace RailGo.AI.Models;
+
+/// <summary>
+/// Mirrors the Python backend's /api/settings response (get_frontend_payload).
+/// </summary>
+public class AISettingsPayload
+{
+    [JsonPropertyName("schema_version")]
+    public int SchemaVersion { get; set; }
+
+    [JsonPropertyName("provider")]
+    public string Provider { get; set; } = "deepseek";
+
+    [JsonPropertyName("providers")]
+    public List<ProviderOption> Providers { get; set; } = new();
+
+    [JsonPropertyName("has_api_key")]
+    public bool HasApiKey { get; set; }
+
+    [JsonPropertyName("has_primary_api_key")]
+    public bool HasPrimaryApiKey { get; set; }
+
+    [JsonPropertyName("has_thinking_api_key")]
+    public bool HasThinkingApiKey { get; set; }
+
+    [JsonPropertyName("masked_api_key")]
+    public string MaskedApiKey { get; set; } = "";
+
+    [JsonPropertyName("masked_primary_api_key")]
+    public string MaskedPrimaryApiKey { get; set; } = "";
+
+    [JsonPropertyName("masked_thinking_api_key")]
+    public string MaskedThinkingApiKey { get; set; } = "";
+
+    [JsonPropertyName("thinking_uses_primary_fallback")]
+    public bool ThinkingUsesPrimaryFallback { get; set; }
+
+    [JsonPropertyName("config_path")]
+    public string ConfigPath { get; set; } = "";
+
+    [JsonPropertyName("updated_at")]
+    public string UpdatedAt { get; set; } = "";
+
+    [JsonPropertyName("account")]
+    public AccountInfo? Account { get; set; }
+
+    [JsonPropertyName("busy")]
+    public bool Busy { get; set; }
+}
+
+public class ProviderOption
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; } = "";
+
+    [JsonPropertyName("label")]
+    public string Label { get; set; } = "";
+
+    [JsonPropertyName("description")]
+    public string Description { get; set; } = "";
+
+    [JsonPropertyName("supports_custom_base_url")]
+    public bool SupportsCustomBaseUrl { get; set; }
+}
+
+public class AccountInfo
+{
+    [JsonPropertyName("status")]
+    public string Status { get; set; } = "";
+
+    [JsonPropertyName("title")]
+    public string Title { get; set; } = "";
+
+    [JsonPropertyName("description")]
+    public string Description { get; set; } = "";
+}

--- a/RailGo.AI/Models/ChatConversation.cs
+++ b/RailGo.AI/Models/ChatConversation.cs
@@ -1,0 +1,56 @@
+namespace RailGo.AI.Models;
+
+/// <summary>
+/// Metadata for a single conversation returned by RailGPT.
+/// </summary>
+public class ChatConversation
+{
+    public int Id { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public DateTime CreatedAt { get; set; }
+    public DateTime UpdatedAt { get; set; }
+    public int MessageCount { get; set; }
+
+    /// <summary>Formatted updated-at string for display (relative or absolute).</summary>
+    public string UpdatedAtText =>
+        UpdatedAt.Date == DateTime.Now.Date
+            ? UpdatedAt.ToString("HH:mm")
+            : UpdatedAt.ToString("MM-dd HH:mm");
+}
+
+/// <summary>
+/// Full conversation detail including messages.
+/// </summary>
+public class ChatConversationDetail
+{
+    public int Id { get; set; }
+    public string Title { get; set; } = string.Empty;
+    public List<ChatConversationMessage> Messages { get; set; } = new();
+}
+
+public class ChatConversationMessage
+{
+    public string Role { get; set; } = string.Empty;  // "user" | "ai" | "system"
+    public string Content { get; set; } = string.Empty;
+    public List<ChatAttachment>? Attachments { get; set; }
+    public DateTime Timestamp { get; set; }
+}
+
+public class ConversationListResponse
+{
+    public List<ChatConversation> Conversations { get; set; } = new();
+}
+
+public class SuggestionItem
+{
+    public string Label { get; set; } = string.Empty;
+    public string Text { get; set; } = string.Empty;
+}
+
+public class ServerStatus
+{
+    public bool Busy { get; set; }
+    public int? CurrentId { get; set; }
+    public bool HasApiKey { get; set; }
+    public bool HasThinkingApiKey { get; set; }
+}

--- a/RailGo.AI/Models/ChatEvent.cs
+++ b/RailGo.AI/Models/ChatEvent.cs
@@ -1,0 +1,48 @@
+namespace RailGo.AI.Models;
+
+/// <summary>
+/// Represents a single SSE event from the RailGPT /api/chat stream.
+/// </summary>
+public class ChatEvent
+{
+    /// <summary>token | thinking | pending | attachment | done | error | heartbeat | psw</summary>
+    public string Type { get; set; } = string.Empty;
+
+    /// <summary>Text payload (token text, thinking text, error message, etc.)</summary>
+    public string? Text { get; set; }
+
+    /// <summary>Attachment data when type == "attachment"</summary>
+    public ChatAttachment? Attachment { get; set; }
+
+    /// <summary>Conversation ID when type == "done"</summary>
+    public int? Cid { get; set; }
+
+    /// <summary>Conversation title when type == "done"</summary>
+    public string? Title { get; set; }
+}
+
+/// <summary>
+/// Attachment embedded in an AI response (geo route, coach image, etc.)
+/// </summary>
+public class ChatAttachment
+{
+    public string? Type { get; set; }
+    public string? Content { get; set; }
+    public string? MimeType { get; set; }
+    public Dictionary<string, object>? Meta { get; set; }
+
+    // ===== Computed bindable properties for x:Bind =====
+
+    public bool IsImage => string.Equals(Type, "image", StringComparison.OrdinalIgnoreCase);
+    public bool IsNotImage => !IsImage;
+    public string Label => Type?.ToLowerInvariant() switch
+    {
+        "image" => "图片",
+        "code" => "代码",
+        "route_map" => "线路地图",
+        "table" => "数据表格",
+        "chart" => "图表",
+        "file" => "文件",
+        _ => Type ?? "附件",
+    };
+}

--- a/RailGo.AI/Models/ChatMessage.cs
+++ b/RailGo.AI/Models/ChatMessage.cs
@@ -1,0 +1,113 @@
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace RailGo.AI.Models;
+
+/// <summary>
+/// UI-facing message displayed in the chat view. Implements INPC for x:Bind reactivity.
+/// Attachments collection changes automatically trigger HasAttachments re-evaluation.
+/// </summary>
+public class ChatMessage : INotifyPropertyChanged
+{
+    private string _content = string.Empty;
+    private string? _thinking;
+    private bool _isStreaming;
+    private bool _isThinkingExpanded;
+    private ObservableCollection<ChatAttachment> _attachments;
+    private ChatMessageRole _role;
+
+    public string Id { get; set; } = Guid.NewGuid().ToString("N")[..8];
+    public DateTime Timestamp { get; set; } = DateTime.Now;
+
+    public ChatMessage()
+    {
+        _attachments = new ObservableCollection<ChatAttachment>();
+        _attachments.CollectionChanged += (_, _) =>
+        {
+            OnPropertyChanged(nameof(HasAttachments));
+        };
+    }
+
+    public ChatMessageRole Role
+    {
+        get => _role;
+        set
+        {
+            _role = value;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(IsAIMessage));
+            OnPropertyChanged(nameof(IsUserMessage));
+            OnPropertyChanged(nameof(IsNotStreaming));
+        }
+    }
+
+    public string Content
+    {
+        get => _content;
+        set { _content = value; OnPropertyChanged(); OnPropertyChanged(nameof(HasContent)); }
+    }
+
+    public ObservableCollection<ChatAttachment> Attachments
+    {
+        get => _attachments;
+        set
+        {
+            if (_attachments != null)
+                _attachments.CollectionChanged -= OnAttachmentsCollectionChanged;
+            _attachments = value;
+            if (_attachments != null)
+                _attachments.CollectionChanged += OnAttachmentsCollectionChanged;
+            OnPropertyChanged();
+            OnPropertyChanged(nameof(HasAttachments));
+        }
+    }
+
+    public string? Thinking
+    {
+        get => _thinking;
+        set { _thinking = value; OnPropertyChanged(); OnPropertyChanged(nameof(HasThinking)); }
+    }
+
+    public bool IsStreaming
+    {
+        get => _isStreaming;
+        set { _isStreaming = value; OnPropertyChanged(); OnPropertyChanged(nameof(IsNotStreaming)); }
+    }
+
+    public bool IsThinkingExpanded
+    {
+        get => _isThinkingExpanded;
+        set { _isThinkingExpanded = value; OnPropertyChanged(); }
+    }
+
+    // ===== Computed bindable properties for x:Bind =====
+
+    public bool IsAIMessage => Role == ChatMessageRole.AI;
+    public bool IsUserMessage => Role == ChatMessageRole.User;
+    public bool HasThinking => !string.IsNullOrWhiteSpace(Thinking);
+    public bool HasContent => !string.IsNullOrWhiteSpace(Content);
+    public bool HasAttachments => Attachments.Count > 0;
+    public bool IsNotStreaming => Role == ChatMessageRole.AI && !IsStreaming;
+
+    public string TimestampText => Timestamp.ToString("HH:mm");
+
+    public event PropertyChangedEventHandler? PropertyChanged;
+
+    protected void OnPropertyChanged([CallerMemberName] string? name = null)
+    {
+        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+    }
+
+    private void OnAttachmentsCollectionChanged(object? sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+    {
+        OnPropertyChanged(nameof(HasAttachments));
+    }
+}
+
+public enum ChatMessageRole
+{
+    User,
+    AI,
+    System
+}

--- a/RailGo.AI/RailGo.AI.csproj
+++ b/RailGo.AI/RailGo.AI.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>RailGo.AI</RootNamespace>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+  </ItemGroup>
+</Project>

--- a/RailGo.AI/Services/AIChatClient.cs
+++ b/RailGo.AI/Services/AIChatClient.cs
@@ -1,0 +1,204 @@
+using System.Net.Http.Json;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+using RailGo.AI.Models;
+
+namespace RailGo.AI.Services;
+
+public class AIChatClient : IAIChatClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly IPythonProcessManager _processManager;
+    private readonly ILogger<AIChatClient>? _logger;
+
+    public string BaseUrl => _processManager.BaseUrl;
+
+    public AIChatClient(HttpClient httpClient, IPythonProcessManager processManager, ILogger<AIChatClient>? logger = null)
+    {
+        // Create a dedicated HttpClient for AI streaming requests
+        // (the shared singleton may have already sent requests, preventing property changes)
+        _httpClient = new HttpClient { Timeout = TimeSpan.FromMinutes(10) };
+        _processManager = processManager;
+        _logger = logger;
+    }
+
+    public async IAsyncEnumerable<ChatEvent> SendMessageAsync(string text, [EnumeratorCancellation] CancellationToken ct = default)
+    {
+        var payload = JsonConvert.SerializeObject(new { text });
+        var content = new StringContent(payload, Encoding.UTF8, "application/json");
+
+        var request = new HttpRequestMessage(HttpMethod.Post, $"{BaseUrl}/api/chat")
+        {
+            Content = content,
+        };
+        request.Headers.Accept.Add(new System.Net.Http.Headers.MediaTypeWithQualityHeaderValue("text/event-stream"));
+
+        // Send request — catch error before any yield return
+        HttpResponseMessage? response = null;
+        Exception? sendError = null;
+        try
+        {
+            response = await _httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, ct);
+            response.EnsureSuccessStatusCode();
+        }
+        catch (Exception ex)
+        {
+            sendError = ex;
+        }
+
+        if (sendError != null || response == null)
+        {
+            _logger?.LogError(sendError, "Failed to send chat message.");
+            yield return new ChatEvent { Type = "error", Text = sendError?.Message ?? "Unknown error" };
+            yield break;
+        }
+
+        // Read SSE stream — all yield points are OUTSIDE try-catch blocks
+        using var stream = await response.Content.ReadAsStreamAsync(ct);
+        using var reader = new StreamReader(stream, Encoding.UTF8);
+
+        while (!reader.EndOfStream && !ct.IsCancellationRequested)
+        {
+            string? line;
+            try
+            {
+                line = await reader.ReadLineAsync(ct);
+            }
+            catch
+            {
+                yield break;
+            }
+            if (line == null) break;
+
+            if (line.StartsWith("data: "))
+            {
+                var json = line.Substring(6);
+                ChatEvent? ev = null;
+                try
+                {
+                    ev = JsonConvert.DeserializeObject<ChatEvent>(json);
+                }
+                catch (JsonException ex)
+                {
+                    _logger?.LogDebug(ex, "Failed to parse SSE event: {Json}", json);
+                }
+
+                if (ev != null)
+                {
+                    yield return ev;
+                    if (ev.Type is "done" or "error")
+                        yield break;
+                }
+            }
+        }
+    }
+
+    public async Task<List<ChatConversation>> GetConversationsAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            var response = await _httpClient.GetFromJsonAsync<ConversationListResponse>(
+                $"{BaseUrl}/api/conversations", ct);
+            return response?.Conversations ?? new List<ChatConversation>();
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Failed to get conversations.");
+            return new List<ChatConversation>();
+        }
+    }
+
+    public async Task<ChatConversationDetail?> CreateConversationAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            var response = await _httpClient.PostAsync($"{BaseUrl}/api/conversations", null, ct);
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<ChatConversationDetail>(cancellationToken: ct);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Failed to create conversation.");
+            return null;
+        }
+    }
+
+    public async Task<ChatConversationDetail?> LoadConversationAsync(int cid, CancellationToken ct = default)
+    {
+        try
+        {
+            var response = await _httpClient.PostAsync($"{BaseUrl}/api/conversations/{cid}/load", null, ct);
+            // Fallback: some versions use GET
+            if (!response.IsSuccessStatusCode)
+                response = await _httpClient.GetAsync($"{BaseUrl}/api/conversations/{cid}", ct);
+
+            response.EnsureSuccessStatusCode();
+            return await response.Content.ReadFromJsonAsync<ChatConversationDetail>(cancellationToken: ct);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Failed to load conversation {Cid}.", cid);
+            return null;
+        }
+    }
+
+    public async Task<bool> DeleteConversationAsync(int cid, CancellationToken ct = default)
+    {
+        try
+        {
+            var response = await _httpClient.DeleteAsync($"{BaseUrl}/api/conversations/{cid}", ct);
+            return response.IsSuccessStatusCode;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Failed to delete conversation {Cid}.", cid);
+            return false;
+        }
+    }
+
+    public async Task<bool> RenameConversationAsync(int cid, string title, CancellationToken ct = default)
+    {
+        try
+        {
+            var payload = JsonConvert.SerializeObject(new { title });
+            var content = new StringContent(payload, Encoding.UTF8, "application/json");
+            var response = await _httpClient.PutAsync($"{BaseUrl}/api/conversations/{cid}/rename", content, ct);
+            return response.IsSuccessStatusCode;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Failed to rename conversation {Cid}.", cid);
+            return false;
+        }
+    }
+
+    public async Task<List<SuggestionItem>> GetSuggestionsAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            return await _httpClient.GetFromJsonAsync<List<SuggestionItem>>(
+                $"{BaseUrl}/api/suggestions", ct) ?? new List<SuggestionItem>();
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Failed to get suggestions.");
+            return new List<SuggestionItem>();
+        }
+    }
+
+    public async Task<ServerStatus?> GetStatusAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            return await _httpClient.GetFromJsonAsync<ServerStatus>(
+                $"{BaseUrl}/api/status", ct);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Failed to get server status.");
+            return null;
+        }
+    }
+}

--- a/RailGo.AI/Services/AISettingsService.cs
+++ b/RailGo.AI/Services/AISettingsService.cs
@@ -1,0 +1,99 @@
+using System.Net.Http.Json;
+using System.Text.Json;
+using RailGo.AI.Models;
+
+namespace RailGo.AI.Services;
+
+/// <summary>
+/// Communicates with the RailGPT Python backend's settings API
+/// to fetch and save API configuration (provider, API keys).
+/// </summary>
+public class AISettingsService
+{
+    private readonly HttpClient _httpClient;
+    private readonly IPythonProcessManager _processManager;
+
+    public AISettingsService(HttpClient httpClient, IPythonProcessManager processManager)
+    {
+        _httpClient = httpClient;
+        _processManager = processManager;
+    }
+
+    private string BaseUrl => _processManager.BaseUrl;
+
+    /// <summary>
+    /// Fetch current RailGPT API settings from the Python backend.
+    /// Returns null if the backend is unreachable.
+    /// </summary>
+    public async Task<AISettingsPayload?> GetSettingsAsync()
+    {
+        if (!_processManager.IsRunning) return null;
+
+        try
+        {
+            using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+            var resp = await _httpClient.GetAsync($"{BaseUrl}/api/settings", cts.Token);
+            if (!resp.IsSuccessStatusCode) return null;
+
+            return await resp.Content.ReadFromJsonAsync<AISettingsPayload>(
+                new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    /// <summary>
+    /// Save API key settings to the Python backend.
+    /// Returns the updated payload on success, or throws on error.
+    /// </summary>
+    public async Task<AISettingsPayload?> SaveApiSettingsAsync(
+        string provider,
+        string? primaryApiKey,
+        string? thinkingApiKey)
+    {
+        if (!_processManager.IsRunning)
+            throw new InvalidOperationException("RailGPT 后端未运行");
+
+        var body = new Dictionary<string, object> { ["provider"] = provider };
+        if (primaryApiKey != null) body["primary_api_key"] = primaryApiKey;
+        if (thinkingApiKey != null) body["thinking_api_key"] = thinkingApiKey;
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        var resp = await _httpClient.PutAsJsonAsync($"{BaseUrl}/api/settings/api", body, cts.Token);
+
+        if (!resp.IsSuccessStatusCode)
+        {
+            var error = await resp.Content.ReadFromJsonAsync<JsonElement>();
+            var msg = error.TryGetProperty("error", out var e) ? e.GetString() : "保存失败";
+            throw new InvalidOperationException(msg ?? "保存 API 设置失败");
+        }
+
+        return await resp.Content.ReadFromJsonAsync<AISettingsPayload>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+    }
+
+    /// <summary>
+    /// Delete the API key for a given slot.
+    /// </summary>
+    public async Task<AISettingsPayload?> DeleteApiKeyAsync(string slot = "primary")
+    {
+        if (!_processManager.IsRunning)
+            throw new InvalidOperationException("RailGPT 后端未运行");
+
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        var resp = await _httpClient.DeleteAsync(
+            $"{BaseUrl}/api/settings/api?slot={slot}", cts.Token);
+
+        if (!resp.IsSuccessStatusCode)
+        {
+            var error = await resp.Content.ReadFromJsonAsync<JsonElement>();
+            var msg = error.TryGetProperty("error", out var e) ? e.GetString() : "删除失败";
+            throw new InvalidOperationException(msg ?? "删除 API Key 失败");
+        }
+
+        return await resp.Content.ReadFromJsonAsync<AISettingsPayload>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+    }
+}

--- a/RailGo.AI/Services/IAIChatClient.cs
+++ b/RailGo.AI/Services/IAIChatClient.cs
@@ -1,0 +1,36 @@
+using RailGo.AI.Models;
+
+namespace RailGo.AI.Services;
+
+/// <summary>
+/// Client for the RailGPT Flask backend HTTP/SSE API.
+/// </summary>
+public interface IAIChatClient
+{
+    /// <summary>Send a message and receive SSE events as a stream.</summary>
+    IAsyncEnumerable<ChatEvent> SendMessageAsync(string text, CancellationToken ct = default);
+
+    /// <summary>Get all conversations.</summary>
+    Task<List<ChatConversation>> GetConversationsAsync(CancellationToken ct = default);
+
+    /// <summary>Create a new conversation.</summary>
+    Task<ChatConversationDetail?> CreateConversationAsync(CancellationToken ct = default);
+
+    /// <summary>Load a conversation by ID.</summary>
+    Task<ChatConversationDetail?> LoadConversationAsync(int cid, CancellationToken ct = default);
+
+    /// <summary>Delete a conversation.</summary>
+    Task<bool> DeleteConversationAsync(int cid, CancellationToken ct = default);
+
+    /// <summary>Rename a conversation.</summary>
+    Task<bool> RenameConversationAsync(int cid, string title, CancellationToken ct = default);
+
+    /// <summary>Get suggestion cards.</summary>
+    Task<List<SuggestionItem>> GetSuggestionsAsync(CancellationToken ct = default);
+
+    /// <summary>Get server status.</summary>
+    Task<ServerStatus?> GetStatusAsync(CancellationToken ct = default);
+
+    /// <summary>Base URL of the backend.</summary>
+    string BaseUrl { get; }
+}

--- a/RailGo.AI/Services/IPythonProcessManager.cs
+++ b/RailGo.AI/Services/IPythonProcessManager.cs
@@ -1,0 +1,25 @@
+namespace RailGo.AI.Services;
+
+/// <summary>
+/// Manages the lifecycle of the RailGPT Python backend process.
+/// </summary>
+public interface IPythonProcessManager
+{
+    /// <summary>Base URL of the running Flask server (e.g. http://localhost:5033).</summary>
+    string BaseUrl { get; }
+
+    /// <summary>Whether the Python backend is running and healthy.</summary>
+    bool IsRunning { get; }
+
+    /// <summary>Raised when the backend status changes.</summary>
+    event EventHandler<bool>? StatusChanged;
+
+    /// <summary>Start the Python backend process. Safe to call multiple times.</summary>
+    Task StartAsync();
+
+    /// <summary>Gracefully stop the Python backend.</summary>
+    Task StopAsync();
+
+    /// <summary>Check health endpoint and update IsRunning.</summary>
+    Task<bool> HealthCheckAsync();
+}

--- a/RailGo.AI/Services/PythonProcessManager.cs
+++ b/RailGo.AI/Services/PythonProcessManager.cs
@@ -1,0 +1,362 @@
+using System.Diagnostics;
+using System.Net;
+using System.Net.Sockets;
+using Microsoft.Extensions.Logging;
+
+namespace RailGo.AI.Services;
+
+/// <summary>
+/// Manages the RailGPT Python backend lifecycle.
+/// Port selection: tries 5033 first (like Jupyter Notebook auto-find),
+/// increments until an available port is found. Reports actual port via <see cref="BaseUrl"/>.
+/// </summary>
+public class PythonProcessManager : IPythonProcessManager, IDisposable
+{
+    private const int DEFAULT_PORT = 5033;
+    private const int MAX_PORT_TRIES = 100;  // 5033..5132
+    private const int MAX_RESTART_ATTEMPTS = 3;
+    private const int HEALTH_CHECK_INTERVAL_MS = 5000;
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<PythonProcessManager>? _logger;
+    private CancellationTokenSource? _healthCts;
+    private Process? _process;
+    private int _restartCount;
+    private int _actualPort;
+    private bool _disposed;
+
+    /// <summary>Base URL of the running Flask server with actual port (e.g. http://localhost:5034).</summary>
+    public string BaseUrl => $"http://localhost:{_actualPort}";
+
+    public bool IsRunning { get; private set; }
+
+    public event EventHandler<bool>? StatusChanged;
+
+    public PythonProcessManager(HttpClient httpClient, ILogger<PythonProcessManager>? logger = null)
+    {
+        _httpClient = httpClient;
+        _httpClient.Timeout = TimeSpan.FromSeconds(5);
+        _logger = logger;
+        _actualPort = DEFAULT_PORT;
+    }
+
+    // ================================================================
+    // Public API
+    // ================================================================
+
+    public async Task StartAsync()
+    {
+        if (_process != null && !_process.HasExited)
+        {
+            _logger?.LogInformation("RailGPT backend already running on port {Port}.", _actualPort);
+            return;
+        }
+
+        // Check if an existing healthy backend is already running on the default port
+        _actualPort = DEFAULT_PORT;
+        if (await HealthCheckAsync())
+        {
+            _logger?.LogInformation("Reusing existing RailGPT backend on port {Port}.", _actualPort);
+            IsRunning = true;
+            StatusChanged?.Invoke(this, true);
+            _healthCts = new CancellationTokenSource();
+            _ = PeriodicHealthCheckAsync(_healthCts.Token);
+            return;
+        }
+
+        var pythonPath = FindPython();
+        if (pythonPath == null)
+        {
+            _logger?.LogError("Python runtime not found. RailGPT backend cannot start.");
+            return;
+        }
+
+        var railGptDir = FindRailGptDirectory();
+        if (railGptDir == null)
+        {
+            _logger?.LogError("RailGPT project directory not found (web_app.py missing).");
+            return;
+        }
+
+        // --- Jupyter-style auto port find ---
+        _actualPort = await FindAvailablePortAsync(DEFAULT_PORT);
+        _logger?.LogInformation("RailGPT binding to port {Port}.", _actualPort);
+
+        // Build the inline Python bootstrap script
+        var bootstrap = BuildBootstrapScript(railGptDir, _actualPort);
+
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = pythonPath,
+            Arguments = $"-c \"{EscapePythonArg(bootstrap)}\"",
+            WorkingDirectory = railGptDir,
+            UseShellExecute = false,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+            CreateNoWindow = true,
+        };
+        startInfo.Environment["RAILGPT_PORT"] = _actualPort.ToString();
+        startInfo.Environment["RAILGPT_MODE"] = "server";
+
+        _process = new Process { StartInfo = startInfo, EnableRaisingEvents = true };
+        _process.OutputDataReceived += (_, e) =>
+        {
+            if (!string.IsNullOrEmpty(e.Data))
+                _logger?.LogInformation("RailGPT: {Line}", e.Data);
+        };
+        _process.ErrorDataReceived += (_, e) =>
+        {
+            if (!string.IsNullOrEmpty(e.Data))
+                _logger?.LogWarning("RailGPT[err]: {Line}", e.Data);
+        };
+        _process.Exited += OnProcessExited;
+
+        try
+        {
+            _process.Start();
+            _process.BeginOutputReadLine();
+            _process.BeginErrorReadLine();
+
+            var healthy = await WaitForServerAsync(TimeSpan.FromSeconds(30));
+            if (healthy)
+            {
+                IsRunning = true;
+                _restartCount = 0;
+                StatusChanged?.Invoke(this, true);
+                _logger?.LogInformation("RailGPT backend healthy on {Url}.", BaseUrl);
+
+                _healthCts = new CancellationTokenSource();
+                _ = PeriodicHealthCheckAsync(_healthCts.Token);
+            }
+            else
+            {
+                _logger?.LogWarning("RailGPT did not respond on port {Port} within timeout.", _actualPort);
+                await StopAsync();
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Failed to launch RailGPT process.");
+        }
+    }
+
+    public async Task StopAsync()
+    {
+        _healthCts?.Cancel();
+
+        if (_process != null && !_process.HasExited)
+        {
+            try { await _httpClient.GetAsync($"{BaseUrl}/api/shutdown"); }
+            catch { /* best-effort graceful shutdown */ }
+
+            if (!_process.HasExited)
+            {
+                _process.Kill(entireProcessTree: true);
+                await Task.Run(() => _process.WaitForExit(5000));
+            }
+        }
+
+        IsRunning = false;
+        StatusChanged?.Invoke(this, false);
+        _logger?.LogInformation("RailGPT backend on port {Port} stopped.", _actualPort);
+    }
+
+    public async Task<bool> HealthCheckAsync()
+    {
+        try
+        {
+            var resp = await _httpClient.GetAsync($"{BaseUrl}/api/status");
+            return resp.IsSuccessStatusCode;
+        }
+        catch { return false; }
+    }
+
+    // ================================================================
+    // Port finding (Jupyter style)
+    // ================================================================
+
+    /// <summary>
+    /// Find the first available port starting from <paramref name="startPort"/>.
+    /// Tries up to MAX_PORT_TRIES ports (like Jupyter's port auto-increment).
+    /// </summary>
+    private static async Task<int> FindAvailablePortAsync(int startPort)
+    {
+        for (int port = startPort; port < startPort + MAX_PORT_TRIES; port++)
+        {
+            if (await IsPortAvailableAsync(port))
+                return port;
+        }
+        // Fallback: let OS pick a random port
+        return FindRandomAvailablePort();
+    }
+
+    private static Task<bool> IsPortAvailableAsync(int port)
+    {
+        try
+        {
+            var listener = new TcpListener(IPAddress.Loopback, port);
+            listener.Start();
+            listener.Stop();
+            return Task.FromResult(true);
+        }
+        catch (SocketException)
+        {
+            return Task.FromResult(false);
+        }
+    }
+
+    private static int FindRandomAvailablePort()
+    {
+        var listener = new TcpListener(IPAddress.Loopback, 0);
+        listener.Start();
+        int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+        listener.Stop();
+        return port;
+    }
+
+    // ================================================================
+    // Internal helpers
+    // ================================================================
+
+    private static string BuildBootstrapScript(string railGptDir, int port)
+    {
+        // Use Python raw string r'...' — backslashes are literal, no escaping needed
+        return $"import sys; sys.path.insert(0, r'{railGptDir}'); " +
+               $"from web_app import app; from app_init import build_backend; " +
+               $"app = build_backend(); " +
+               $"from werkzeug.serving import run_simple; " +
+               $"run_simple('127.0.0.1', {port}, app, threaded=True)";
+    }
+
+    private static string EscapePythonArg(string script)
+    {
+        // Escape double-quotes for safe embedding in -c "..."
+        return script.Replace("\"", "\\\"");
+    }
+
+    private async Task<bool> WaitForServerAsync(TimeSpan timeout)
+    {
+        var deadline = DateTime.UtcNow + timeout;
+        while (DateTime.UtcNow < deadline)
+        {
+            if (await HealthCheckAsync())
+                return true;
+            await Task.Delay(500);
+        }
+        return false;
+    }
+
+    private async Task PeriodicHealthCheckAsync(CancellationToken ct)
+    {
+        while (!ct.IsCancellationRequested)
+        {
+            await Task.Delay(HEALTH_CHECK_INTERVAL_MS, ct);
+            if (ct.IsCancellationRequested) break;
+
+            if (!await HealthCheckAsync() && IsRunning)
+            {
+                _logger?.LogWarning("Health check failed for port {Port}.", _actualPort);
+                await TryRestartAsync();
+            }
+        }
+    }
+
+    private async Task TryRestartAsync()
+    {
+        if (_restartCount >= MAX_RESTART_ATTEMPTS)
+        {
+            _logger?.LogError("RailGPT restart limit ({Max}) reached. Giving up.", MAX_RESTART_ATTEMPTS);
+            IsRunning = false;
+            StatusChanged?.Invoke(this, false);
+            return;
+        }
+        _restartCount++;
+        _logger?.LogInformation("Restarting RailGPT (attempt {Attempt}/{Max}).", _restartCount, MAX_RESTART_ATTEMPTS);
+        await StopAsync();
+        await Task.Delay(1000);
+        await StartAsync();
+    }
+
+    private void OnProcessExited(object? sender, EventArgs e)
+    {
+        if (!_disposed)
+        {
+            _logger?.LogWarning("RailGPT process exited (code {Code}).", _process?.ExitCode);
+            IsRunning = false;
+            StatusChanged?.Invoke(this, false);
+        }
+    }
+
+    // ================================================================
+    // Discovery
+    // ================================================================
+
+    private static string? FindPython()
+    {
+        // Priority: known working paths first, then fallback to PATH lookup
+        var candidates = new[]
+        {
+            // Known working anaconda environment (from user memory)
+            @"D:\Users\tomat\anaconda3\python.exe",
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                @"anaconda3\python.exe"),
+            // Standard Python installs
+            @"C:\Python314\python.exe",
+            @"C:\Python312\python.exe", @"C:\Python311\python.exe",
+            @"D:\Python312\python.exe", @"D:\Python311\python.exe",
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                @"Programs\Python\Python312\python.exe"),
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                @"Programs\Python\Python311\python.exe"),
+            // Generic PATH lookup (last resort)
+            @"python.exe",
+            "python3",
+            "python",
+        };
+        foreach (var c in candidates)
+        {
+            try
+            {
+                var psi = new ProcessStartInfo
+                {
+                    FileName = c, Arguments = "--version",
+                    UseShellExecute = false, RedirectStandardOutput = true,
+                    RedirectStandardError = true, CreateNoWindow = true,
+                };
+                using var p = Process.Start(psi);
+                if (p != null)
+                {
+                    p.WaitForExit(5000);
+                    if (p.ExitCode == 0) return c;
+                }
+            }
+            catch { /* candidate not found or not executable */ }
+        }
+        return null;
+    }
+
+    private static string? FindRailGptDirectory()
+    {
+        var candidates = new[]
+        {
+            // Priority: local copy first
+            @"D:\Desktop\RailGo\RailGPT",
+            Path.Combine(AppContext.BaseDirectory, "RailGPT"),
+            Path.Combine(AppContext.BaseDirectory, "..", "..", "..", "..", "RailGPT"),
+        };
+        foreach (var c in candidates)
+        {
+            if (Directory.Exists(c) && File.Exists(Path.Combine(c, "web_app.py")))
+                return c;
+        }
+        return null;
+    }
+
+    public void Dispose()
+    {
+        if (_disposed) return;
+        _disposed = true;
+        _healthCts?.Cancel();
+        _process?.Dispose();
+        _healthCts?.Dispose();
+    }
+}

--- a/RailGo/App.xaml
+++ b/RailGo/App.xaml
@@ -10,6 +10,10 @@
                 <ResourceDictionary Source="/Styles/Thickness.xaml" />
                 <ResourceDictionary Source="/Styles/TextBlock.xaml" />
             </ResourceDictionary.MergedDictionaries>
+            <helpers:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter"
+                xmlns:helpers="using:RailGo.Helpers"/>
+            <helpers:BoolToGreenRedConverter x:Key="BoolToGreenRedConverter"
+                xmlns:helpers="using:RailGo.Helpers"/>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/RailGo/App.xaml.cs
+++ b/RailGo/App.xaml.cs
@@ -22,12 +22,15 @@ using RailGo.ViewModels.Pages.Settings.DataSources;
 using RailGo.ViewModels.Pages.Shell;
 using RailGo.ViewModels.Pages.Stations;
 using RailGo.ViewModels.Pages.StationToStation;
+using RailGo.AI.Services;
+using RailGo.ViewModels.Pages.Chat;
 using RailGo.ViewModels.Pages.TrainEmus;
 using RailGo.ViewModels.Pages.Trains;
 using RailGo.ViewModels.Windows;
 using RailGo.Views;
 using RailGo.Views.Windows;
 using RailGo.Views.ContentDialogs;
+using RailGo.Views.Pages.Chat;
 using RailGo.Views.Pages.Settings;
 using RailGo.Views.Pages.Settings.DataSources;
 using RailGo.Views.Pages.Shell;
@@ -142,6 +145,14 @@ public partial class App : Application
             services.AddTransient<DataSources_ThirdPartyApiServicesPage>();
             services.AddTransient<DataSources_ThirdPartyDatabasesPage>();
 
+            // AI Services (RailGPT integration)
+            services.AddSingleton<HttpClient>();
+            services.AddSingleton<IPythonProcessManager, PythonProcessManager>();
+            services.AddSingleton<IAIChatClient, AIChatClient>();
+            services.AddSingleton<AISettingsService>();
+            services.AddTransient<ChatViewModel>();
+            services.AddTransient<ChatPage>();
+
             // Configuration
             services.Configure<LocalSettingsOptions>(context.Configuration.GetSection(nameof(LocalSettingsOptions)));
         }).
@@ -181,6 +192,20 @@ public partial class App : Application
         DataSourcesShell.CheckAvailableModes();
 
         base.OnLaunched(args);
+
+        // Start RailGPT Python backend in background (non-blocking)
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                var processManager = App.GetService<IPythonProcessManager>();
+                await processManager.StartAsync();
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"RailGPT backend startup failed: {ex.Message}");
+            }
+        });
         // App.GetService<IAppNotificationService>().Show(string.Format("AppNotificationSamplePayload".GetLocalized(), AppContext.BaseDirectory));
         await App.GetService<IActivationService>().ActivateAsync(args);
     }

--- a/RailGo/Controls/MarkdownRenderer.cs
+++ b/RailGo/Controls/MarkdownRenderer.cs
@@ -1,0 +1,546 @@
+using Markdig;
+using Markdig.Extensions.Tables;
+using Markdig.Syntax;
+using Markdig.Syntax.Inlines;
+using Microsoft.UI.Text;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Documents;
+using Microsoft.UI.Xaml.Media;
+using Windows.UI;
+using Windows.UI.Text;
+using MdBlock = Markdig.Syntax.Block;
+using MdInline = Markdig.Syntax.Inlines.Inline;
+using WBlock = Microsoft.UI.Xaml.Documents.Block;
+using WInline = Microsoft.UI.Xaml.Documents.Inline;
+
+namespace RailGo.Controls;
+
+/// <summary>
+/// Converts Markdown text (via Markdig) into WinUI 3 RichTextBlock Block elements.
+/// Used by MarkdownTextBlock control and can be reused elsewhere.
+/// </summary>
+public static class MarkdownRenderer
+{
+    private static readonly MarkdownPipeline Pipeline = new MarkdownPipelineBuilder()
+        .UseAdvancedExtensions()
+        .Build();
+
+    // ==================== Public API ====================
+
+    /// <summary>Render markdown text into a RichTextBlock.</summary>
+    public static void Render(RichTextBlock target, string markdown)
+    {
+        target.Blocks.Clear();
+        if (string.IsNullOrWhiteSpace(markdown))
+            return;
+
+        try
+        {
+            var document = Markdig.Markdown.Parse(markdown, Pipeline);
+            foreach (var block in document)
+            {
+                var rendered = RenderBlock(block, target);
+                if (rendered != null)
+                    target.Blocks.Add(rendered);
+            }
+        }
+        catch
+        {
+            // Fallback to plain text on parse error (e.g., streaming partial markdown)
+            target.Blocks.Add(PlainParagraph(markdown));
+        }
+    }
+
+    /// <summary>Render inline-only markdown into Inline elements for a Paragraph.</summary>
+    public static IEnumerable<WInline> RenderInlines(string markdown, Paragraph parent)
+    {
+        var document = Markdig.Markdown.Parse(markdown, Pipeline);
+        foreach (var block in document)
+        {
+            if (block is ParagraphBlock para)
+            {
+                foreach (var inline in para.Inline!)
+                    yield return RenderInline(inline, parent);
+            }
+        }
+    }
+
+    // ==================== Block Renderers ====================
+
+    private static WBlock? RenderBlock(MdBlock block, RichTextBlock rtb)
+    {
+        return block switch
+        {
+            ParagraphBlock pb => RenderParagraph(pb),
+            HeadingBlock hb => RenderHeading(hb),
+            FencedCodeBlock fcb => new Paragraph { Inlines = { RenderFencedCode(fcb) } },
+            CodeBlock cb => new Paragraph { Inlines = { RenderCodeBlock(cb) } },
+            ListBlock lb => RenderList(lb, rtb),
+            QuoteBlock qb => RenderQuote(qb),
+            ThematicBreakBlock => RenderThematicBreak(),
+            Table tb => new Paragraph { Inlines = { RenderTable(tb) } },
+            _ => null,
+        };
+    }
+
+    private static Paragraph RenderParagraph(ParagraphBlock pb)
+    {
+        var p = new Paragraph { LineHeight = 22 };
+        if (pb.Inline != null)
+        {
+            foreach (var inline in pb.Inline)
+                p.Inlines.Add(RenderInline(inline, p));
+        }
+        return p;
+    }
+
+    private static Paragraph RenderHeading(HeadingBlock hb)
+    {
+        var p = new Paragraph();
+        double fontSize = hb.Level switch
+        {
+            1 => 24,
+            2 => 20,
+            3 => 17,
+            4 => 15,
+            _ => 14,
+        };
+        var weight = hb.Level <= 2 ? FontWeights.SemiBold : FontWeights.Normal;
+        p.Margin = hb.Level switch
+        {
+            1 => new Thickness(0, 16, 0, 8),
+            2 => new Thickness(0, 12, 0, 6),
+            _ => new Thickness(0, 8, 0, 4),
+        };
+
+        if (hb.Inline != null)
+        {
+            // Wrap all inlines with heading styling
+            var contentRun = new Run();
+            foreach (var inline in hb.Inline)
+            {
+                // Flatten heading content into styled text
+                FlattenInlineToText(inline, contentRun);
+            }
+            contentRun.FontSize = fontSize;
+            contentRun.FontWeight = weight;
+            p.Inlines.Add(contentRun);
+        }
+        return p;
+    }
+
+    private static void FlattenInlineToText(MdInline inline, Run target)
+    {
+        if (inline is LiteralInline lit)
+        {
+            if (!string.IsNullOrEmpty(target.Text))
+                target.Text += lit.Content.ToString();
+            else
+                target.Text = lit.Content.ToString();
+        }
+        else if (inline is EmphasisInline em && em.FirstChild is MdInline child)
+        {
+            FlattenInlineToText(child, target);
+        }
+    }
+
+    private static InlineUIContainer RenderFencedCode(FencedCodeBlock fcb)
+    {
+        return BuildCodeContainer(
+            fcb.Lines.ToString(),
+            fcb.Info?.Replace("\\", "") ?? "");
+    }
+
+    private static InlineUIContainer RenderCodeBlock(CodeBlock cb)
+    {
+        return BuildCodeContainer(cb.Lines.ToString(), "");
+    }
+
+    private static InlineUIContainer BuildCodeContainer(string code, string language)
+    {
+        var headerText = string.IsNullOrWhiteSpace(language) ? "代码" : language;
+
+        var stack = new StackPanel();
+
+        // Language label bar
+        var headerBorder = new Border
+        {
+            Background = new SolidColorBrush(Color.FromArgb(0x40, 0x00, 0x00, 0x00)),
+            Padding = new Thickness(12, 4, 12, 4),
+            CornerRadius = new CornerRadius(8, 8, 0, 0),
+        };
+        var headerTb = new TextBlock
+        {
+            Text = headerText,
+            FontSize = 11,
+            Foreground = new SolidColorBrush(Color.FromArgb(0xFF, 0x88, 0x88, 0x88)),
+            FontFamily = new FontFamily("Segoe UI"),
+        };
+        headerBorder.Child = headerTb;
+        stack.Children.Add(headerBorder);
+
+        // Code text
+        var codeTb = new TextBlock
+        {
+            Text = code.TrimEnd(),
+            FontFamily = new FontFamily("Consolas"),
+            FontSize = 13,
+            Padding = new Thickness(12, 8, 12, 8),
+            TextWrapping = TextWrapping.Wrap,
+            Foreground = new SolidColorBrush(Color.FromArgb(0xFF, 0xDD, 0xDD, 0xDD)),
+        };
+        stack.Children.Add(codeTb);
+
+        var outerBorder = new Border
+        {
+            Background = new SolidColorBrush(Color.FromArgb(0xFF, 0x1E, 0x1E, 0x1E)),
+            CornerRadius = new CornerRadius(8),
+            Child = stack,
+            Margin = new Thickness(0, 6, 0, 6),
+        };
+
+        return new InlineUIContainer { Child = outerBorder };
+    }
+
+    private static Paragraph RenderList(ListBlock lb, RichTextBlock rtb)
+    {
+        var container = new Paragraph();
+        bool isOrdered = lb.IsOrdered;
+        int index = 1;
+
+        foreach (var item in lb)
+        {
+            if (item is ListItemBlock li)
+            {
+                var prefix = isOrdered ? $"{index}. " : "  •  ";
+                index++;
+
+                var prefixRun = new Run { Text = prefix };
+                container.Inlines.Add(prefixRun);
+
+                if (li.Count > 0 && li[0] is ParagraphBlock itemPara && itemPara.Inline != null)
+                {
+                    foreach (var inline in itemPara.Inline)
+                        container.Inlines.Add(RenderInline(inline, container));
+                }
+
+                container.Inlines.Add(new LineBreak());
+            }
+        }
+        container.Margin = new Thickness(4, 2, 0, 2);
+        return container;
+    }
+
+    private static Paragraph RenderQuote(QuoteBlock qb)
+    {
+        // Render inner blocks inline with a left-accent border look
+        var p = new Paragraph
+        {
+            Margin = new Thickness(0, 4, 0, 4),
+        };
+
+        // Left accent bar via InlineUIContainer
+        var accentBar = new Border
+        {
+            Width = 3,
+            Background = new SolidColorBrush(Color.FromArgb(0xFF, 0x60, 0x60, 0x60)),
+            CornerRadius = new CornerRadius(2),
+        };
+
+        foreach (var block in qb)
+        {
+            if (block is ParagraphBlock qPara && qPara.Inline != null)
+            {
+                foreach (var inline in qPara.Inline)
+                    p.Inlines.Add(RenderInline(inline, p));
+            }
+        }
+        return p;
+    }
+
+    private static Paragraph RenderThematicBreak()
+    {
+        var border = new Border
+        {
+            Height = 1,
+            Background = new SolidColorBrush(Color.FromArgb(0x40, 0x80, 0x80, 0x80)),
+            Margin = new Thickness(0, 12, 0, 12),
+        };
+        var p = new Paragraph();
+        p.Inlines.Add(new InlineUIContainer { Child = border });
+        return p;
+    }
+
+    private static InlineUIContainer RenderTable(Table table)
+    {
+        if (!table.Any()) return new InlineUIContainer { Child = new TextBlock { Text = "" } };
+
+        // Count max columns across all rows
+        int colCount = 0;
+        foreach (TableRow row in table)
+            colCount = Math.Max(colCount, row.Count);
+
+        // Count rows (including header)
+        int rowCount = table.Count();
+        bool hasHeader = rowCount > 0;
+
+        var grid = new Grid
+        {
+            Margin = new Thickness(0, 6, 0, 6),
+            BorderThickness = new Thickness(1),
+            BorderBrush = new SolidColorBrush(Color.FromArgb(0x30, 0x80, 0x80, 0x80)),
+            CornerRadius = new CornerRadius(6),
+        };
+
+        for (int c = 0; c < colCount; c++)
+            grid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto, MinWidth = 80 });
+
+        int r = 0;
+        foreach (TableRow tableRow in table)
+        {
+            grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+
+            bool isHeader = hasHeader && r == 0;
+            int c = 0;
+            foreach (TableCell cell in tableRow)
+            {
+                if (c >= colCount) break;
+
+                string cellText = ExtractPlainText(cell);
+                var cellTb = new TextBlock
+                {
+                    Text = cellText,
+                    FontSize = 13,
+                    FontWeight = isHeader ? FontWeights.SemiBold : FontWeights.Normal,
+                    Padding = new Thickness(10, 6, 10, 6),
+                    TextWrapping = TextWrapping.Wrap,
+                };
+
+                var cellBorder = new Border
+                {
+                    Background = isHeader
+                        ? new SolidColorBrush(global::Windows.UI.Color.FromArgb(0x15, 0x00, 0x00, 0x00))
+                        : new SolidColorBrush(Microsoft.UI.Colors.Transparent),
+                    Child = cellTb,
+                };
+
+                Grid.SetRow(cellBorder, r);
+                Grid.SetColumn(cellBorder, c);
+                grid.Children.Add(cellBorder);
+                c++;
+            }
+            r++;
+        }
+
+        var outerBorder = new Border
+        {
+            Child = new ScrollViewer
+            {
+                HorizontalScrollBarVisibility = ScrollBarVisibility.Auto,
+                HorizontalScrollMode = ScrollMode.Auto,
+                Content = grid,
+            },
+            Margin = new Thickness(0, 6, 0, 6),
+        };
+
+        return new InlineUIContainer { Child = outerBorder };
+    }
+
+    private static string ExtractPlainText(TableCell cell)
+    {
+        if (cell.Count == 0) return "";
+        var sb = new System.Text.StringBuilder();
+        foreach (var item in cell)
+        {
+            if (item is ParagraphBlock pb && pb.Inline != null)
+            {
+                foreach (var inline in pb.Inline)
+                    AppendInlineText(inline, sb);
+            }
+        }
+        return sb.ToString().Trim();
+    }
+
+    private static void AppendInlineText(MdInline inline, System.Text.StringBuilder sb)
+    {
+        if (inline is LiteralInline lit)
+            sb.Append(lit.Content.ToString());
+        else if (inline is CodeInline ci)
+            sb.Append(ci.Content);
+        else if (inline is EmphasisInline em)
+        {
+            foreach (var child in em)
+                if (child is MdInline childInline)
+                    AppendInlineText(childInline, sb);
+        }
+        else if (inline is LinkInline link)
+        {
+            foreach (var child in link)
+                if (child is MdInline childInline)
+                    AppendInlineText(childInline, sb);
+        }
+        else if (inline is LineBreakInline)
+            sb.Append(' ');
+    }
+
+    // ==================== Inline Renderers ====================
+
+    private static WInline RenderInline(MdInline inline, Paragraph parent)
+    {
+        return inline switch
+        {
+            LiteralInline lit => new Run { Text = lit.Content.ToString() },
+            CodeInline code => RenderCodeInline(code),
+            EmphasisInline em => RenderEmphasis(em, parent),
+            LinkInline link => RenderLink(link),
+            LineBreakInline => new LineBreak(),
+            HtmlEntityInline he => new Run { Text = he.Transcoded.ToString() },
+            HtmlInline => new Run(), // Skip raw HTML
+            _ => RenderFallbackInline(inline, parent),
+        };
+    }
+
+    private static WInline RenderCodeInline(CodeInline code)
+    {
+        // Subtle monospace + background for inline code
+        var border = new Border
+        {
+            Background = new SolidColorBrush(Color.FromArgb(0x20, 0x00, 0x00, 0x00)),
+            CornerRadius = new CornerRadius(3),
+            Padding = new Thickness(4, 1, 4, 1),
+        };
+        var tb = new TextBlock
+        {
+            Text = code.Content,
+            FontFamily = new FontFamily("Consolas"),
+            FontSize = 12.5,
+        };
+        border.Child = tb;
+        return new InlineUIContainer { Child = border };
+    }
+
+    private static WInline RenderEmphasis(EmphasisInline em, Paragraph parent)
+    {
+        // em.DelimiterChar: '*' = emphasis (italic), '~' variants = strikethrough
+        bool isBold = em.DelimiterCount == 2 && (em.DelimiterChar == '*' || em.DelimiterChar == '_');
+        bool isStrike = em.DelimiterChar == '~';
+
+        if (isStrike)
+        {
+            var strikeSpan = new Span();
+            if (em.FirstChild is MdInline child)
+            {
+                if (child is LiteralInline lit)
+                    strikeSpan.Inlines.Add(new Run { Text = lit.Content.ToString() });
+                else
+                    strikeSpan.Inlines.Add(RenderInline(child, parent));
+            }
+            // Underline used as strikethrough approximation in WinUI
+            foreach (var run in FlattenSpanToRuns(strikeSpan))
+                run.TextDecorations = TextDecorations.Strikethrough;
+            return strikeSpan.Inlines.Count > 0 ? strikeSpan.Inlines[0] : new Run();
+        }
+
+        if (isBold)
+        {
+            var bold = new Bold();
+            foreach (var child in em)
+            {
+                if (child is MdInline childInline)
+                    bold.Inlines.Add(RenderInline(childInline, parent));
+            }
+            return bold;
+        }
+        else
+        {
+            var italic = new Italic();
+            foreach (var child in em)
+            {
+                if (child is MdInline childInline)
+                    italic.Inlines.Add(RenderInline(childInline, parent));
+            }
+            return italic;
+        }
+    }
+
+    private static List<Run> FlattenSpanToRuns(Span span)
+    {
+        var runs = new List<Run>();
+        foreach (var inline in span.Inlines)
+        {
+            if (inline is Run r)
+                runs.Add(r);
+            else if (inline is Span childSpan)
+                runs.AddRange(FlattenSpanToRuns(childSpan));
+            else if (inline is Bold b)
+                foreach (var bi in b.Inlines)
+                    if (bi is Run br) runs.Add(br);
+            else if (inline is Italic i)
+                foreach (var ii in i.Inlines)
+                    if (ii is Run ir) runs.Add(ir);
+        }
+        return runs;
+    }
+
+    private static WInline RenderLink(LinkInline link)
+    {
+        var hyperlink = new Hyperlink();
+        try
+        {
+            hyperlink.NavigateUri = new Uri(link.Url);
+        }
+        catch { /* ignore invalid URLs */ }
+
+        hyperlink.UnderlineStyle = UnderlineStyle.Single;
+        hyperlink.Foreground = new SolidColorBrush(Color.FromArgb(0xFF, 0x4D, 0xA3, 0xF2));
+
+        // Link text
+        string linkText;
+        if (link.IsImage)
+        {
+            linkText = $"[图片: {link.Url}]";
+        }
+        else
+        {
+            var sb = new System.Text.StringBuilder();
+            foreach (var child in link)
+            {
+                if (child is LiteralInline lit)
+                    sb.Append(lit.Content.ToString());
+                else if (child is CodeInline ci)
+                    sb.Append(ci.Content);
+            }
+            linkText = sb.Length > 0 ? sb.ToString() : link.Url ?? link.Label ?? "";
+        }
+
+        hyperlink.Inlines.Add(new Run { Text = linkText });
+        return hyperlink;
+    }
+
+    private static WInline RenderFallbackInline(MdInline inline, Paragraph parent)
+    {
+        // Generic handler for unknown inline types: try to extract text
+        if (inline is ContainerInline ci)
+        {
+            var span = new Span();
+            foreach (var child in ci)
+            {
+                if (child is MdInline childInline)
+                    span.Inlines.Add(RenderInline(childInline, parent));
+            }
+            if (span.Inlines.Count > 0)
+                return (WInline)span.Inlines[0];
+        }
+        return new Run { Text = inline.ToString() ?? "" };
+    }
+
+    // ==================== Helpers ====================
+
+    private static Paragraph PlainParagraph(string text)
+    {
+        var p = new Paragraph();
+        p.Inlines.Add(new Run { Text = text });
+        return p;
+    }
+}

--- a/RailGo/Controls/MarkdownTextBlock.xaml
+++ b/RailGo/Controls/MarkdownTextBlock.xaml
@@ -1,0 +1,14 @@
+<UserControl
+    x:Class="RailGo.Controls.MarkdownTextBlock"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <RichTextBlock x:Name="ContentBlock"
+                   TextWrapping="Wrap"
+                   IsTextSelectionEnabled="True"
+                   LineHeight="22"
+                   Foreground="{ThemeResource TextFillColorPrimaryBrush}" />
+</UserControl>

--- a/RailGo/Controls/MarkdownTextBlock.xaml.cs
+++ b/RailGo/Controls/MarkdownTextBlock.xaml.cs
@@ -1,0 +1,81 @@
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+
+namespace RailGo.Controls;
+
+/// <summary>
+/// Reusable Markdown-rendering control for WinUI 3.
+/// Bind Text to any markdown string; renders as formatted RichTextBlock content.
+/// </summary>
+public sealed partial class MarkdownTextBlock : UserControl
+{
+    // ==================== Dependency Properties ====================
+
+    public static readonly DependencyProperty TextProperty =
+        DependencyProperty.Register(
+            nameof(Text),
+            typeof(string),
+            typeof(MarkdownTextBlock),
+            new PropertyMetadata(string.Empty, OnTextChanged));
+
+    public static readonly DependencyProperty IsMarkdownProperty =
+        DependencyProperty.Register(
+            nameof(IsMarkdown),
+            typeof(bool),
+            typeof(MarkdownTextBlock),
+            new PropertyMetadata(true, OnTextChanged));
+
+    /// <summary>The markdown text to render.</summary>
+    public string Text
+    {
+        get => (string)GetValue(TextProperty);
+        set => SetValue(TextProperty, value);
+    }
+
+    /// <summary>When false, renders as plain text (no markdown processing).</summary>
+    public bool IsMarkdown
+    {
+        get => (bool)GetValue(IsMarkdownProperty);
+        set => SetValue(IsMarkdownProperty, value);
+    }
+
+    // ==================== Constructor ====================
+
+    public MarkdownTextBlock()
+    {
+        InitializeComponent();
+    }
+
+    // ==================== Rendering ====================
+
+    private static void OnTextChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+    {
+        if (d is MarkdownTextBlock control)
+        {
+            // Always re-render from the current Text property value,
+            // since e.NewValue may be a bool (from IsMarkdown changes) not a string.
+            control.RenderContent(control.Text);
+        }
+    }
+
+    private void RenderContent(string text)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            ContentBlock.Blocks.Clear();
+            return;
+        }
+
+        if (IsMarkdown)
+        {
+            MarkdownRenderer.Render(ContentBlock, text);
+        }
+        else
+        {
+            ContentBlock.Blocks.Clear();
+            var p = new Microsoft.UI.Xaml.Documents.Paragraph();
+            p.Inlines.Add(new Microsoft.UI.Xaml.Documents.Run { Text = text });
+            ContentBlock.Blocks.Add(p);
+        }
+    }
+}

--- a/RailGo/Helpers/BoolToGreenRedConverter.cs
+++ b/RailGo/Helpers/BoolToGreenRedConverter.cs
@@ -1,0 +1,29 @@
+using Microsoft.UI;
+using Microsoft.UI.Xaml.Data;
+using Microsoft.UI.Xaml.Media;
+using WColor = Windows.UI.Color;
+
+namespace RailGo.Helpers;
+
+/// <summary>
+/// Converts bool to a green SolidColorBrush when true, red/gray when false.
+/// Used for backend status indicator dots.
+/// </summary>
+public class BoolToGreenRedConverter : IValueConverter
+{
+    private static readonly SolidColorBrush GreenBrush = new(WColor.FromArgb(255, 34, 197, 94));
+    private static readonly SolidColorBrush RedBrush = new(WColor.FromArgb(255, 239, 68, 68));
+    private static readonly SolidColorBrush GrayBrush = new(WColor.FromArgb(255, 156, 163, 175));
+
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        if (value is bool b)
+            return b ? GreenBrush : RedBrush;
+        return GrayBrush;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/RailGo/RailGo.csproj
+++ b/RailGo/RailGo.csproj
@@ -1,9 +1,9 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows10.0.22621.0</TargetFramework>
+    <TargetFramework>net8.0-windows10.0.26100.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
-    <WindowsSdkPackageVersion>10.0.22621.38</WindowsSdkPackageVersion>
+    <WindowsSdkPackageVersion>10.0.26100.38</WindowsSdkPackageVersion>
     <RootNamespace>RailGo</RootNamespace>
     <ApplicationIcon>Assets/WindowIcon.ico</ApplicationIcon>
     <ApplicationManifest>app.manifest</ApplicationManifest>
@@ -13,6 +13,8 @@
 	<ImplicitUsings>enable</ImplicitUsings>
 	<Nullable>enable</Nullable>
 	<UseWinUI>true</UseWinUI>
+	<WindowsAppSdkBootstrapInitialize>true</WindowsAppSdkBootstrapInitialize>
+	<WindowsAppSdkDeploymentManagerInitialize>false</WindowsAppSdkDeploymentManagerInitialize>
     <EnableMsixTooling>true</EnableMsixTooling>
     <GenerateAppInstallerFile>False</GenerateAppInstallerFile>
     <AppxPackageSigningEnabled>True</AppxPackageSigningEnabled>
@@ -23,7 +25,6 @@
     <AppxBundle>Never</AppxBundle>
     <GenerateTemporaryStoreCertificate>True</GenerateTemporaryStoreCertificate>
     <DefaultLanguage>zh-cn</DefaultLanguage>
-    <PackageCertificateKeyFile>RailGo_TemporaryKey.pfx</PackageCertificateKeyFile>
     <Version>0.1.3.0</Version>
     <AssemblyVersion>0.1.3.0</AssemblyVersion>
     <FileVersion>0.1.3.0</FileVersion>
@@ -40,14 +41,17 @@
     <PackageReference Include="CommunityToolkit.WinUI.Controls.SettingsControls" Version="8.1.240916" />
     <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.DataGrid" Version="7.1.2" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Web.WebView2" Version="1.0.4078.44" />
     <PackageReference Include="Microsoft.Windows.CsWinRT" Version="2.2.0" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.6.241114003" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="2.3.1" />
+    <PackageReference Include="Markdig" Version="0.37.0" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.WinUI.Managed" Version="2.0.9" />
     <PackageReference Include="WinUIEx" Version="2.5.0" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\RailGo.Core\RailGo.Core.csproj" />
+    <ProjectReference Include="..\RailGo.AI\RailGo.AI.csproj" />
   </ItemGroup>
   <ItemGroup>
     <None Update="appsettings.json">
@@ -61,9 +65,8 @@
   <ItemGroup Condition="'$(DisableMsixProjectCapabilityAddedByProject)'!='true' and '$(EnableMsixTooling)'=='true'">
     <ProjectCapability Include="Msix" />
   </ItemGroup>
-  
+
   <PropertyGroup Condition="'$(DisableHasPackageAndPublishMenuAddedByProject)'!='true' and '$(EnableMsixTooling)'=='true'">
     <HasPackageAndPublishMenu>true</HasPackageAndPublishMenu>
   </PropertyGroup>
 </Project>
-

--- a/RailGo/Services/PageService.cs
+++ b/RailGo/Services/PageService.cs
@@ -5,13 +5,18 @@ using Microsoft.UI.Xaml.Controls;
 using RailGo.Contracts.Services;
 using RailGo.Views;
 
+using RailGo.ViewModels.Pages.Chat;
 using RailGo.ViewModels.Pages.Shell;
 using RailGo.ViewModels.Pages.Settings;
 using RailGo.ViewModels.Pages.Settings.DataSources;
+using RailGo.ViewModels.Pages.TrainEmus;
 using RailGo.ViewModels.Pages.Trains;
+using RailGo.ViewModels.Pages.Stations;
+using RailGo.ViewModels.Pages.StationToStation;
 using RailGo.ViewModels.Pages.TrainEmus;
 using RailGo.ViewModels.Pages.Stations;
 using RailGo.ViewModels.Pages.StationToStation;
+using RailGo.Views.Pages.Chat;
 using RailGo.Views.Pages.Shell;
 using RailGo.Views.Pages.Settings;
 using RailGo.Views.Pages.Settings.DataSources;
@@ -43,6 +48,9 @@ public class PageService : IPageService
         Configure<DataSources_OnlineDatabasesViewModel, DataSources_OnlineDatabasesPage>();
         Configure<DataSources_ThirdPartyApiServicesViewModel, DataSources_ThirdPartyApiServicesPage>();
         Configure<DataSources_ThirdPartyDatabasesViewModel, DataSources_ThirdPartyDatabasesPage>();
+
+        // AI Chat page
+        Configure<ChatViewModel, ChatPage>();
     }
 
     public Type GetPageType(string key)

--- a/RailGo/ViewModels/Pages/Chat/ChatViewModel.cs
+++ b/RailGo/ViewModels/Pages/Chat/ChatViewModel.cs
@@ -1,0 +1,100 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Microsoft.UI.Dispatching;
+using RailGo.AI.Services;
+using RailGo.Contracts.ViewModels;
+
+namespace RailGo.ViewModels.Pages.Chat;
+
+/// <summary>
+/// Thin ViewModel for the Chat page — the actual chat UI is rendered by
+/// RailGPT's web frontend via WebView2. This class only manages the
+/// Python backend lifecycle and exposes a BackendReady event.
+/// </summary>
+public partial class ChatViewModel : ObservableObject, INavigationAware
+{
+    private readonly IPythonProcessManager _processManager;
+    private readonly DispatcherQueue _dispatcher;
+    private EventHandler<bool>? _statusHandler;
+
+    /// <summary>Fired when the RailGPT backend is ready, providing the URL for WebView2.</summary>
+    public event Action<string>? BackendReady;
+
+    [ObservableProperty]
+    private bool _isBackendRunning;
+
+    [ObservableProperty]
+    private string _statusText = "正在启动 RailGPT 后端…";
+
+    public ChatViewModel(IPythonProcessManager processManager)
+    {
+        _processManager = processManager;
+        _dispatcher = DispatcherQueue.GetForCurrentThread();
+    }
+
+    public async Task InitializeAsync()
+    {
+        // Subscribe to backend status changes
+        _statusHandler = (_, running) =>
+        {
+            _dispatcher.TryEnqueue(() =>
+            {
+                IsBackendRunning = running;
+                StatusText = running ? "就绪" : "后端未连接";
+            });
+        };
+        _processManager.StatusChanged += _statusHandler;
+
+        // Start backend if not already running
+        if (!_processManager.IsRunning)
+        {
+            await _processManager.StartAsync();
+        }
+
+        // Notify WebView2 to load the RailGPT frontend
+        if (_processManager.IsRunning)
+        {
+            IsBackendRunning = true;
+            StatusText = "就绪";
+            var url = _processManager.BaseUrl;
+            _dispatcher.TryEnqueue(() => BackendReady?.Invoke(url));
+        }
+        else
+        {
+            // Retry a few times
+            for (int i = 0; i < 5 && !_processManager.IsRunning; i++)
+            {
+                await Task.Delay(1000);
+            }
+            if (_processManager.IsRunning)
+            {
+                IsBackendRunning = true;
+                StatusText = "就绪";
+                var url = _processManager.BaseUrl;
+                _dispatcher.TryEnqueue(() => BackendReady?.Invoke(url));
+            }
+            else
+            {
+                StatusText = "RailGPT 后端启动失败";
+            }
+        }
+    }
+
+    public void Cleanup()
+    {
+        if (_statusHandler != null)
+            _processManager.StatusChanged -= _statusHandler;
+    }
+
+    /// <summary>Called by the navigation framework when navigating to this page.</summary>
+    public async void OnNavigatedTo(object parameter)
+    {
+        await InitializeAsync();
+    }
+
+    /// <summary>Called by the navigation framework when navigating away from this page.</summary>
+    public void OnNavigatedFrom()
+    {
+        Cleanup();
+    }
+}

--- a/RailGo/ViewModels/Pages/Settings/SettingsViewModel.cs
+++ b/RailGo/ViewModels/Pages/Settings/SettingsViewModel.cs
@@ -2,6 +2,8 @@
 using System.Windows.Input;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using RailGo.AI.Models;
+using RailGo.AI.Services;
 using RailGo.Contracts.Services;
 using RailGo.Helpers;
 using Microsoft.UI.Xaml;
@@ -13,7 +15,9 @@ namespace RailGo.ViewModels.Pages.Settings;
 public partial class SettingsViewModel : ObservableRecipient
 {
     private readonly IThemeSelectorService _themeSelectorService;
+    private readonly AISettingsService? _aiSettingsService;
 
+    // ---- Theme ----
     [ObservableProperty]
     private ElementTheme _elementTheme;
 
@@ -22,11 +26,51 @@ public partial class SettingsViewModel : ObservableRecipient
 
     public ICommand SwitchThemeCommand { get; }
 
+    // ---- AI / RailGPT API Settings ----
+    [ObservableProperty]
+    private bool _isAISettingsLoaded;
+
+    [ObservableProperty]
+    private bool _isAISettingsLoading;
+
+    [ObservableProperty]
+    private string _aiStatusMessage = "";
+
+    [ObservableProperty]
+    private string _selectedProvider = "deepseek";
+
+    [ObservableProperty]
+    private string _primaryApiKeyInput = "";
+
+    [ObservableProperty]
+    private string _thinkingApiKeyInput = "";
+
+    [ObservableProperty]
+    private string _maskedPrimaryKeyDisplay = "";
+
+    [ObservableProperty]
+    private string _maskedThinkingKeyDisplay = "";
+
+    [ObservableProperty]
+    private bool _hasApiKeyConfigured;
+
+    [ObservableProperty]
+    private bool _isAISaving;
+
+    [ObservableProperty]
+    private string _aiConfigUpdatedAt = "";
+
+    public ICommand LoadAISettingsCommand { get; }
+    public ICommand SaveAISettingsCommand { get; }
+    public ICommand ClearPrimaryApiKeyCommand { get; }
+    public ICommand ClearThinkingApiKeyCommand { get; }
+
     public SettingsViewModel(IThemeSelectorService themeSelectorService)
     {
         _themeSelectorService = themeSelectorService;
         _elementTheme = _themeSelectorService.Theme;
         _versionDescription = GetVersionDescription();
+
         SwitchThemeCommand = new RelayCommand<ElementTheme>(
             async (param) =>
             {
@@ -36,6 +80,137 @@ public partial class SettingsViewModel : ObservableRecipient
                     await _themeSelectorService.SetThemeAsync(param);
                 }
             });
+
+        // AI settings service is optional — may be null if not registered
+        _aiSettingsService = App.GetService<AISettingsService>();
+
+        LoadAISettingsCommand = new RelayCommand(async () => await LoadAISettingsAsync());
+        SaveAISettingsCommand = new RelayCommand(async () => await SaveAISettingsAsync());
+        ClearPrimaryApiKeyCommand = new RelayCommand(async () => await ClearApiKeyAsync("primary"));
+        ClearThinkingApiKeyCommand = new RelayCommand(async () => await ClearApiKeyAsync("thinking"));
+    }
+
+    // ---- AI Settings logic ----
+
+    /// <summary>
+    /// Fetch current API settings from the RailGPT Python backend.
+    /// </summary>
+    public async Task LoadAISettingsAsync()
+    {
+        if (_aiSettingsService == null) return;
+
+        IsAISettingsLoading = true;
+        AiStatusMessage = "正在读取 RailGPT 设置…";
+
+        try
+        {
+            var payload = await _aiSettingsService.GetSettingsAsync();
+            if (payload == null)
+            {
+                AiStatusMessage = "RailGPT 后端未连接，请稍后重试";
+                IsAISettingsLoaded = false;
+                return;
+            }
+
+            SelectedProvider = payload.Provider;
+            HasApiKeyConfigured = payload.HasApiKey;
+            MaskedPrimaryKeyDisplay = payload.MaskedPrimaryApiKey;
+            MaskedThinkingKeyDisplay = payload.MaskedThinkingApiKey;
+            AiConfigUpdatedAt = payload.UpdatedAt;
+            IsAISettingsLoaded = true;
+            AiStatusMessage = payload.HasApiKey
+                ? $"已配置 ({payload.Provider})"
+                : "未配置 API Key";
+        }
+        catch (Exception ex)
+        {
+            AiStatusMessage = $"读取失败: {ex.Message}";
+            IsAISettingsLoaded = false;
+        }
+        finally
+        {
+            IsAISettingsLoading = false;
+            PrimaryApiKeyInput = "";
+            ThinkingApiKeyInput = "";
+        }
+    }
+
+    /// <summary>
+    /// Save API key settings to the RailGPT Python backend.
+    /// </summary>
+    public async Task SaveAISettingsAsync()
+    {
+        if (_aiSettingsService == null || IsAISaving) return;
+
+        var primary = PrimaryApiKeyInput?.Trim();
+        var thinking = ThinkingApiKeyInput?.Trim();
+        if (string.IsNullOrEmpty(primary) && string.IsNullOrEmpty(thinking))
+        {
+            AiStatusMessage = "请至少输入一个 API Key";
+            return;
+        }
+
+        IsAISaving = true;
+        AiStatusMessage = "正在保存…";
+
+        try
+        {
+            var payload = await _aiSettingsService.SaveApiSettingsAsync(
+                SelectedProvider,
+                string.IsNullOrEmpty(primary) ? null : primary,
+                string.IsNullOrEmpty(thinking) ? null : thinking);
+
+            if (payload != null)
+            {
+                HasApiKeyConfigured = payload.HasApiKey;
+                MaskedPrimaryKeyDisplay = payload.MaskedPrimaryApiKey;
+                MaskedThinkingKeyDisplay = payload.MaskedThinkingApiKey;
+                AiConfigUpdatedAt = payload.UpdatedAt;
+                AiStatusMessage = "API 设置已保存 ✓";
+            }
+        }
+        catch (Exception ex)
+        {
+            AiStatusMessage = $"保存失败: {ex.Message}";
+        }
+        finally
+        {
+            IsAISaving = false;
+            PrimaryApiKeyInput = "";
+            ThinkingApiKeyInput = "";
+        }
+    }
+
+    /// <summary>
+    /// Delete a specific API key slot.
+    /// </summary>
+    public async Task ClearApiKeyAsync(string slot)
+    {
+        if (_aiSettingsService == null) return;
+
+        IsAISaving = true;
+        AiStatusMessage = $"正在删除 {slot} API Key…";
+
+        try
+        {
+            var payload = await _aiSettingsService.DeleteApiKeyAsync(slot);
+            if (payload != null)
+            {
+                HasApiKeyConfigured = payload.HasApiKey;
+                MaskedPrimaryKeyDisplay = payload.MaskedPrimaryApiKey;
+                MaskedThinkingKeyDisplay = payload.MaskedThinkingApiKey;
+                AiConfigUpdatedAt = payload.UpdatedAt;
+                AiStatusMessage = $"{slot} API Key 已删除";
+            }
+        }
+        catch (Exception ex)
+        {
+            AiStatusMessage = $"删除失败: {ex.Message}";
+        }
+        finally
+        {
+            IsAISaving = false;
+        }
     }
 
     private static string GetVersionDescription()

--- a/RailGo/Views/Pages/Chat/ChatPage.xaml
+++ b/RailGo/Views/Pages/Chat/ChatPage.xaml
@@ -1,0 +1,9 @@
+<Page
+    x:Class="RailGo.Views.Pages.Chat.ChatPage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:controls="using:Microsoft.UI.Xaml.Controls">
+
+    <!-- RailGPT 原生前端 — WebView2 直接嵌入，100% 复用 -->
+    <controls:WebView2 x:Name="RailGPTWebView" />
+</Page>

--- a/RailGo/Views/Pages/Chat/ChatPage.xaml.cs
+++ b/RailGo/Views/Pages/Chat/ChatPage.xaml.cs
@@ -1,0 +1,79 @@
+using Microsoft.UI.Xaml.Controls;
+using RailGo.AI.Services;
+using RailGo.ViewModels.Pages.Chat;
+
+namespace RailGo.Views.Pages.Chat;
+
+public sealed partial class ChatPage : Page
+{
+    public ChatViewModel ViewModel { get; }
+
+    public ChatPage()
+    {
+        ViewModel = App.GetService<ChatViewModel>();
+        InitializeComponent();
+
+        // Hook WebView2 navigation when backend is ready, with error fallback
+        ViewModel.BackendReady += async url =>
+        {
+            try
+            {
+                await RailGPTWebView.EnsureCoreWebView2Async();
+                RailGPTWebView.CoreWebView2.Navigate(url);
+
+                // Also register for navigation errors in WebView2
+                RailGPTWebView.CoreWebView2.NavigationStarting += (_, args) =>
+                {
+                    System.Diagnostics.Debug.WriteLine($"[WebView2] Navigating to: {args.Uri}");
+                };
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"[WebView2] Failed to load: {ex.Message}");
+                ShowFallbackPage($"导航失败: {ex.Message}");
+            }
+        };
+
+        // Fallback: if backend never becomes ready, show error after 10s
+        _ = ShowFallbackAfterTimeout();
+    }
+
+    private async Task ShowFallbackAfterTimeout()
+    {
+        await Task.Delay(10_000);
+        if (!ViewModel.IsBackendRunning)
+        {
+            try
+            {
+                await RailGPTWebView.EnsureCoreWebView2Async();
+                RailGPTWebView.CoreWebView2.NavigateToString(
+                    "<html><body style='background:#1e1e2e;color:#cdd6f4;display:flex;align-items:center;" +
+                    "justify-content:center;height:100vh;font-family:sans-serif'>" +
+                    "<div style='text-align:center'><h2>RailGPT</h2>" +
+                    "<p>后端服务启动失败，请检查 Python 环境和 RailGPT 项目。</p>" +
+                    $"<p style='color:#a6adc8;font-size:0.9em'>端口: 5033</p></div></body></html>");
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"[WebView2] Fallback error: {ex.Message}");
+            }
+        }
+    }
+
+    private void ShowFallbackPage(string message)
+    {
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                await RailGPTWebView.EnsureCoreWebView2Async();
+                RailGPTWebView.CoreWebView2.NavigateToString(
+                    $"<html><body style='background:#1e1e2e;color:#cdd6f4;display:flex;align-items:center;" +
+                    $"justify-content:center;height:100vh;font-family:sans-serif'>" +
+                    $"<div style='text-align:center'><h2>RailGPT</h2>" +
+                    $"<p>{message}</p></div></body></html>");
+            }
+            catch { }
+        });
+    }
+}

--- a/RailGo/Views/Pages/Settings/SettingsPage.xaml
+++ b/RailGo/Views/Pages/Settings/SettingsPage.xaml
@@ -22,7 +22,7 @@
 
                 <!-- 数据源设置 -->
                 <StackPanel Margin="{StaticResource SmallTopBottomMargin}">
-                    <TextBlock Text="数据源设置" Style="{ThemeResource SubtitleTextBlockStyle}" 
+                    <TextBlock Text="数据源设置" Style="{ThemeResource SubtitleTextBlockStyle}"
                                Margin="{StaticResource XSmallTopMargin}"/>
                     <controls:SettingsCard x:Name="DataSourcesSettingsCard"
                                Click="OnDataSourcesSettingsCardClicked"
@@ -31,6 +31,83 @@
                                HeaderIcon="{ui:FontIcon Glyph=&#xE8A1;}"
                                IsClickEnabled="True"
                                Margin="{StaticResource XSmallTopMargin}">
+                    </controls:SettingsCard>
+                </StackPanel>
+
+                <!-- RailGPT API 设置 -->
+                <TextBlock Text="RailGPT API 设置" Style="{ThemeResource SubtitleTextBlockStyle}"
+                           Margin="{StaticResource XSmallTopMargin}"/>
+                <StackPanel Margin="{StaticResource SmallTopBottomMargin}" Spacing="4">
+                    <!-- Status -->
+                    <InfoBar x:Name="AISettingsInfoBar"
+                             IsOpen="False"
+                             IsClosable="True"
+                             Severity="Informational"
+                             Margin="{StaticResource XSmallTopMargin}" />
+
+                    <controls:SettingsCard
+                               Description="选择 AI 服务提供商"
+                               Header="服务提供商"
+                               HeaderIcon="{ui:FontIcon Glyph=&#xE943;}"
+                               Margin="{StaticResource XSmallTopMargin}">
+                        <ComboBox x:Name="ProviderComboBox"
+                                  MinWidth="200"
+                                  SelectionChanged="ProviderComboBox_SelectionChanged"
+                                  FontSize="14">
+                            <ComboBoxItem Content="DeepSeek" Tag="deepseek" />
+                        </ComboBox>
+                    </controls:SettingsCard>
+
+                    <controls:SettingsCard
+                               Description="用于对话生成的 API Key（必填）"
+                               Header="主对话 API Key"
+                               HeaderIcon="{ui:FontIcon Glyph=&#xE72E;}"
+                               Margin="{StaticResource XSmallTopMargin}">
+                        <StackPanel Spacing="8" MinWidth="280">
+                            <PasswordBox x:Name="PrimaryApiKeyBox"
+                                         PlaceholderText="输入 API Key (sk-...)"
+                                         FontSize="14" />
+                            <TextBlock x:Name="PrimaryKeyStatus"
+                                       FontSize="12"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                       Text="未配置" />
+                            <StackPanel Orientation="Horizontal" Spacing="8">
+                                <Button x:Name="SavePrimaryKeyBtn" Content="保存主对话 Key" Click="OnSavePrimaryKeyClicked" />
+                                <Button x:Name="ClearPrimaryKeyBtn" Content="删除" Click="OnClearPrimaryKeyClicked" />
+                            </StackPanel>
+                        </StackPanel>
+                    </controls:SettingsCard>
+
+                    <controls:SettingsCard
+                               Description="用于深度思考模式的 API Key（选填，不填时复用主对话 Key）"
+                               Header="Thinker API Key"
+                               HeaderIcon="{ui:FontIcon Glyph=&#xE7BE;}"
+                               Margin="{StaticResource XSmallTopMargin}">
+                        <StackPanel Spacing="8" MinWidth="280">
+                            <PasswordBox x:Name="ThinkingApiKeyBox"
+                                         PlaceholderText="输入 Thinker API Key（可选）"
+                                         FontSize="14" />
+                            <TextBlock x:Name="ThinkingKeyStatus"
+                                       FontSize="12"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                       Text="未配置，将自动复用主对话 Key" />
+                            <StackPanel Orientation="Horizontal" Spacing="8">
+                                <Button x:Name="SaveThinkingKeyBtn" Content="保存 Thinker Key" Click="OnSaveThinkingKeyClicked" />
+                                <Button x:Name="ClearThinkingKeyBtn" Content="删除" Click="OnClearThinkingKeyClicked" />
+                            </StackPanel>
+                        </StackPanel>
+                    </controls:SettingsCard>
+
+                    <controls:SettingsCard
+                               Description="加密存储位置"
+                               Header="配置文件"
+                               HeaderIcon="{ui:FontIcon Glyph=&#xE8A5;}"
+                               Margin="{StaticResource XSmallTopMargin}">
+                        <TextBlock x:Name="ConfigPathText"
+                                   Text="%APPDATA%/RailGPT/settings.enc"
+                                   FontSize="12"
+                                   TextWrapping="Wrap"
+                                   Foreground="{ThemeResource TextFillColorSecondaryBrush}" />
                     </controls:SettingsCard>
                 </StackPanel>
 

--- a/RailGo/Views/Pages/Settings/SettingsPage.xaml.cs
+++ b/RailGo/Views/Pages/Settings/SettingsPage.xaml.cs
@@ -29,6 +29,9 @@ public sealed partial class SettingsPage : Page
         UpdateBackgroundImageUiState();
         _backgroundImageService.BackgroundImageChanged -= OnBackgroundImageChanged;
         _backgroundImageService.BackgroundImageChanged += OnBackgroundImageChanged;
+
+        // Load AI settings from Python backend
+        _ = LoadAISettingsAsync();
     }
 
     private void InitializeThemeComboBox()
@@ -182,5 +185,137 @@ public sealed partial class SettingsPage : Page
         var dataPackage = new DataPackage();
         dataPackage.SetText("652032716");
         Clipboard.SetContent(dataPackage);
+    }
+
+    // ============================================================
+    // AI / RailGPT API Settings handlers
+    // ============================================================
+
+    private async Task LoadAISettingsAsync()
+    {
+        await ViewModel.LoadAISettingsAsync();
+        RefreshAIStatusDisplay();
+    }
+
+    private void RefreshAIStatusDisplay()
+    {
+        // Primary key status
+        if (!string.IsNullOrEmpty(ViewModel.MaskedPrimaryKeyDisplay))
+            PrimaryKeyStatus.Text = $"已配置: {ViewModel.MaskedPrimaryKeyDisplay}";
+        else
+            PrimaryKeyStatus.Text = "未配置";
+
+        // Thinking key status
+        if (!string.IsNullOrEmpty(ViewModel.MaskedThinkingKeyDisplay))
+            ThinkingKeyStatus.Text = $"已配置: {ViewModel.MaskedThinkingKeyDisplay}";
+        else
+            ThinkingKeyStatus.Text = "未配置，将自动复用主对话 Key";
+
+        // Config path
+        ConfigPathText.Text = "%APPDATA%/RailGPT/settings.enc";
+
+        // InfoBar
+        if (ViewModel.HasApiKeyConfigured)
+        {
+            AISettingsInfoBar.Severity = Microsoft.UI.Xaml.Controls.InfoBarSeverity.Success;
+            AISettingsInfoBar.Title = "已配置";
+            AISettingsInfoBar.Message = $"Provider: {ViewModel.SelectedProvider} | 更新于: {ViewModel.AiConfigUpdatedAt}";
+            AISettingsInfoBar.IsOpen = true;
+        }
+        else
+        {
+            AISettingsInfoBar.Severity = Microsoft.UI.Xaml.Controls.InfoBarSeverity.Warning;
+            AISettingsInfoBar.Title = "未配置 API Key";
+            AISettingsInfoBar.Message = "请输入 API Key 以启用 RailGPT 对话功能";
+            AISettingsInfoBar.IsOpen = true;
+        }
+    }
+
+    private async void OnSavePrimaryKeyClicked(object sender, RoutedEventArgs e)
+    {
+        var key = PrimaryApiKeyBox.Password?.Trim();
+        if (string.IsNullOrEmpty(key))
+        {
+            AISettingsInfoBar.Severity = Microsoft.UI.Xaml.Controls.InfoBarSeverity.Error;
+            AISettingsInfoBar.Title = "输入为空";
+            AISettingsInfoBar.Message = "请输入主对话 API Key";
+            AISettingsInfoBar.IsOpen = true;
+            return;
+        }
+
+        SavePrimaryKeyBtn.IsEnabled = false;
+        try
+        {
+            ViewModel.PrimaryApiKeyInput = key;
+            ViewModel.ThinkingApiKeyInput = ThinkingApiKeyBox.Password?.Trim() ?? "";
+            await ViewModel.SaveAISettingsAsync();
+            PrimaryApiKeyBox.Password = "";
+            RefreshAIStatusDisplay();
+        }
+        finally
+        {
+            SavePrimaryKeyBtn.IsEnabled = true;
+        }
+    }
+
+    private async void OnClearPrimaryKeyClicked(object sender, RoutedEventArgs e)
+    {
+        ClearPrimaryKeyBtn.IsEnabled = false;
+        try
+        {
+            await ViewModel.ClearApiKeyAsync("primary");
+            RefreshAIStatusDisplay();
+        }
+        finally
+        {
+            ClearPrimaryKeyBtn.IsEnabled = true;
+        }
+    }
+
+    private async void OnSaveThinkingKeyClicked(object sender, RoutedEventArgs e)
+    {
+        var key = ThinkingApiKeyBox.Password?.Trim();
+        if (string.IsNullOrEmpty(key))
+        {
+            AISettingsInfoBar.Severity = Microsoft.UI.Xaml.Controls.InfoBarSeverity.Error;
+            AISettingsInfoBar.Title = "输入为空";
+            AISettingsInfoBar.Message = "请输入 Thinker API Key";
+            AISettingsInfoBar.IsOpen = true;
+            return;
+        }
+
+        SaveThinkingKeyBtn.IsEnabled = false;
+        try
+        {
+            ViewModel.ThinkingApiKeyInput = key;
+            ViewModel.PrimaryApiKeyInput = PrimaryApiKeyBox.Password?.Trim() ?? "";
+            await ViewModel.SaveAISettingsAsync();
+            ThinkingApiKeyBox.Password = "";
+            RefreshAIStatusDisplay();
+        }
+        finally
+        {
+            SaveThinkingKeyBtn.IsEnabled = true;
+        }
+    }
+
+    private async void OnClearThinkingKeyClicked(object sender, RoutedEventArgs e)
+    {
+        ClearThinkingKeyBtn.IsEnabled = false;
+        try
+        {
+            await ViewModel.ClearApiKeyAsync("thinking");
+            RefreshAIStatusDisplay();
+        }
+        finally
+        {
+            ClearThinkingKeyBtn.IsEnabled = true;
+        }
+    }
+
+    private void ProviderComboBox_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (ProviderComboBox.SelectedItem is ComboBoxItem item && item.Tag != null)
+            ViewModel.SelectedProvider = item.Tag.ToString()!;
     }
 }

--- a/RailGo/Views/Pages/Shell/ShellPage.xaml
+++ b/RailGo/Views/Pages/Shell/ShellPage.xaml
@@ -18,7 +18,7 @@
             SelectedItem="{x:Bind ViewModel.Selected, Mode=OneWay}"
             IsSettingsVisible="True"
             ExpandedModeThresholdWidth="1280"
-            Header="{x:Bind ((ContentControl)ViewModel.Selected).Content, Mode=OneWay}">
+            AlwaysShowHeader="False">
 
             <NavigationView.PaneHeader>
                 <StackPanel Orientation="Horizontal" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
@@ -43,11 +43,24 @@
                 <SolidColorBrush x:Key="NavigationViewContentGridBorderBrush" Color="Transparent" />
             </NavigationView.Resources>
             <NavigationView.MenuItems>
+                <!-- Default: RailGo Home (railway query) -->
                 <NavigationViewItem x:Uid="Shell_Main" helpers:NavigationHelper.NavigateTo="RailGo.ViewModels.Pages.Shell.MainViewModel">
                     <NavigationViewItem.Icon>
                         <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE80F;"/>
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
+
+                <!-- AI Chat (RailGPT powered) -->
+                <NavigationViewItem x:Uid="Shell_AI_Chat" helpers:NavigationHelper.NavigateTo="RailGo.ViewModels.Pages.Chat.ChatViewModel" x:Name="AIChatNavItem" Content="RailGPT">
+                    <NavigationViewItem.Icon>
+                        <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE8E2;"/>
+                    </NavigationViewItem.Icon>
+                </NavigationViewItem>
+
+                <!-- Separator -->
+                <NavigationViewItemSeparator/>
+
+                <!-- Railway query sub-items -->
                 <NavigationViewItem x:Uid="Shell_EMU_Routing" helpers:NavigationHelper.NavigateTo="RailGo.ViewModels.Pages.TrainEmus.EMU_RoutingViewModel">
                     <NavigationViewItem.Icon>
                         <FontIcon FontFamily="{StaticResource SymbolThemeFontFamily}" Glyph="&#xE7C0;"/>
@@ -69,15 +82,6 @@
                     </NavigationViewItem.Icon>
                 </NavigationViewItem>
             </NavigationView.MenuItems>
-            <NavigationView.HeaderTemplate>
-                <DataTemplate>
-                    <Grid>
-                        <TextBlock
-                            Text="{Binding}"
-                            Style="{ThemeResource TitleTextBlockStyle}" />
-                    </Grid>
-                </DataTemplate>
-            </NavigationView.HeaderTemplate>
             <Grid Margin="{StaticResource NavigationViewPageContentMargin}">
                 <Frame x:Name="NavigationFrame" />
             </Grid>


### PR DESCRIPTION
## 做了什么

- ChatPage 改用 WebView2 直接嵌入 RailGPT 的原生网页前端，不再自己画 XAML 聊天 UI
- 启动时自动拉起 Python 后端（5033 端口），关了再开能复用已运行的进程
- 设置页新增 RailGPT API 配置，直接读写 Python 那边的加密设置，不用去网页里改
- 去掉了页面顶部标题栏和没用的工具分析页

## 涉及文件

- 新增 **RailGo.AI** 项目（Python 进程管理、聊天客户端、设置服务）
- 重写 ChatPage / ChatViewModel
- SettingsPage 加 API 设置区块
- 修了几个 bug（Python 路径、raw string 转义）

🤖 Generated with [Claude Code](https://claude.com/claude-code)